### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-##Description
+## Description
 
 Small library allowing you to have a VerticalViewPager. It's just a copy paste from the v19 ViewPager available in the support lib, where I changed all the left/right into top/bottom and X into Y.
 
 Nothing complicated here, but you can gain some time avoiding rewriting it. 
 
-##Integration
+## Integration
 
 The lib will be available soon on Maven Central. All you have to do is add it on your gradle build:
 
@@ -14,11 +14,11 @@ dependencies {
 }
 ```
 
-##Note
+## Note
 
 `PageAdapter#getPageWidth()` is used as a `getPageHeight()` in the lib.
 
-##License
+## License
 
 ```
 "THE BEER-WARE LICENSE" (Revision 42):
@@ -26,7 +26,7 @@ You can do whatever you want with this stuff.
 If we meet some day, and you think this stuff is worth it, you can buy me a beer in return.
 ```
 
-####Badges
+#### Badges
 
 [![Analytics](https://ga-beacon.appspot.com/UA-32954204-2/VerticalViewPager/readme)](https://github.com/igrigorik/ga-beacon)
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
